### PR TITLE
fix estimated_time type

### DIFF
--- a/xbox/webapi/api/provider/achievements/models.py
+++ b/xbox/webapi/api/provider/achievements/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, time
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -106,7 +106,7 @@ class Achievement(CamelCaseModel):
     participation_type: str
     time_window: Any
     rewards: List[Reward]
-    estimated_time: time
+    estimated_time: Union[str, time]
     deeplink: Any
     is_revoked: bool
 


### PR DESCRIPTION
xbox API sometimes returns a value which is not a supported format of type datetime.time. This is a hotfix, should be updated to the correct format in future